### PR TITLE
Run ci against multiple python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: python
 python:
+  - "3.3"
+  - "3.4"
   - "3.5"
+  - "3.6"
 install: "pip install -r requirements-ci.txt"
 script: "pytest --cov envargs --cov-report term-missing"
 after_success:


### PR DESCRIPTION
In order to have any credibility that this actually works on more than just the python version I have on my machine, I figured I'd better ask the CI (travis) to run the tests with the versions.

Lets check the PR status.