### PR TITLE
Default parsers

### DIFF
--- a/envargs/__init__.py
+++ b/envargs/__init__.py
@@ -1,4 +1,5 @@
 """Exposed internals of envparse."""
+from . import inputs
 from .models import Var
 from .parser import parse_dict
 from .parser import parse_env

--- a/envargs/inputs.py
+++ b/envargs/inputs.py
@@ -1,0 +1,13 @@
+"""Default value parsers. Does common things simply."""
+
+
+def boolean(value):
+    """Return true if the value indicates a truthiness."""
+    options = {
+        'true',
+        't',
+        '1',
+        'yes',
+    }
+
+    return value.lower() in options

--- a/tests/test_funcs.py
+++ b/tests/test_funcs.py
@@ -1,0 +1,19 @@
+"""Testing the default parser functions."""
+import pytest
+
+from envargs import inputs
+
+
+@pytest.mark.parametrize('case, expected', [
+    ('true', True),
+    ('t', True),
+    ('True', True),
+    ('1', True),
+    ('yes', True),
+    ('0', False),
+    ('false', False),
+    ('no', False),
+])
+def test_boolean_parser(case, expected):
+    """Test the default boolean parser."""
+    assert inputs.boolean(case) == expected


### PR DESCRIPTION
This adds a few functions to help parse some datatypes. This is just suppose to make it less needed to have lambdas all over the place and reducing the need of tiresome redundancy.

- [x] boolean function
- [ ] split by char

Find the right name for the module with the functions. `helpers` seems ok, but as it is already in use, it requires some moving around.