### PR TITLE
Support nested config structures too

### DIFF
--- a/envargs/parser.py
+++ b/envargs/parser.py
@@ -2,27 +2,31 @@
 import os
 
 from . import errors
+from . import models
 
 
 def _load_values(values, fields):
     """Load values according to the fields."""
     for dest, field in fields.items():
-        location = field.load_from or dest
-        value = values.get(location)
+        if isinstance(field, models.Var):
+            location = field.load_from or dest
+            value = values.get(location)
 
-        if value is None:
-            if field.default is None:
-                raise errors.ParseError(
-                    'Required field "{}" missing.'.format(location),
-                    location=location,
-                )
+            if value is None:
+                if field.default is None:
+                    raise errors.ParseError(
+                        'Required field "{}" missing.'.format(location),
+                        location=location,
+                    )
 
-            yield dest, field.default
+                yield dest, field.default
 
-        else:
-            value = field.parse(value, location)
-            field.validate(value, location)
-            yield dest, value
+            else:
+                value = field.parse(value, location)
+                field.validate(value, location)
+                yield dest, value
+        elif isinstance(field, dict):
+            yield dest, dict(_load_values(values, field))
 
 
 def parse_dict(values, fields):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -210,3 +210,25 @@ def test_complex_defaulting():
     assert parse_dict(values, args) == {
         'a_bool': False,
     }
+
+
+def test_nesting():
+    """Make sure we can parse nested structures."""
+    args = {
+        'nested': {
+            'a_str': Var(use=str),
+            'an_int': Var(use=int),
+        },
+    }
+
+    values = {
+        'a_str': 'this-is-my-string',
+        'an_int': '10'
+    }
+
+    assert parse_dict(values, args) == {
+        'nested': {
+            'a_str': 'this-is-my-string',
+            'an_int': 10,
+        },
+    }


### PR DESCRIPTION
Sometimes you need dictionaries to configure things. I have encountered this most often with 3rd party tools that you integrate into an app.

This will make envargs able to support nesting vars gracefully such as:

```python
settings = {
    'nested': {
        'MY_VAR': Var(use=str),
    },
}
```

And envargs will recurse properly to take care of the nested `Var`s.

I suppose this also makes it trivial to add static config vars later on, but that is beyond this PR.