### PR TITLE
Support static vars

### DIFF
--- a/envargs/parser.py
+++ b/envargs/parser.py
@@ -27,6 +27,8 @@ def _load_values(values, fields):
                 yield dest, value
         elif isinstance(field, dict):
             yield dest, dict(_load_values(values, field))
+        elif isinstance(field, (int, float, str, bytes)):
+            yield dest, field
 
 
 def parse_dict(values, fields):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -232,3 +232,29 @@ def test_nesting():
             'an_int': 10,
         },
     }
+
+
+def test_static_vars():
+    """Test that hardcoded vars fall through parsing."""
+    args = {
+        'a_var': Var(
+            use=int,
+            load_from='A_VAR',
+        ),
+        'some_bytes': b'bytes!',
+        'a_string': 'my string',
+        'a_float': 1.5,
+        'a_int': 1,
+    }
+
+    values = {
+        'A_VAR': '0',
+    }
+
+    assert parse_dict(values, args) == {
+        'a_var': 0,
+        'some_bytes': b'bytes!',
+        'a_string': 'my string',
+        'a_float': 1.5,
+        'a_int': 1,
+    }


### PR DESCRIPTION
Hardcoded primitives fallthrough parsing and are returned as is.

This comes in handy in the cases where something is required by other configs, but a static config is fine.

It does make config kind of a three-way train crash, with parsing, defaults, and static vars.