### PR TITLE
Truncate values before evaluation

### DIFF
--- a/envargs/parser.py
+++ b/envargs/parser.py
@@ -22,7 +22,7 @@ def _load_values(values, fields):
                 yield dest, field.default
 
             else:
-                value = field.parse(value, location)
+                value = field.parse(value.strip(), location)
                 field.validate(value, location)
                 yield dest, value
         elif isinstance(field, dict):

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -232,3 +232,29 @@ def test_nesting():
             'an_int': 10,
         },
     }
+
+
+def test_numeric_var_with_spaces():
+    """Test that numbers are parsed properly even if they have spaces."""
+    args = {
+        'an_int': Var(use=int, load_from='AN_INT',),
+    }
+
+    os.environ['AN_INT'] = '0   '
+
+    assert parse_env(args) == {
+        'an_int': 0,
+    }
+
+
+def test_string_var_with_spaces():
+    """Test that string values are truncated."""
+    args = {
+        'a_var': Var(use=str, load_from='A_VAR',),
+    }
+
+    os.environ['A_VAR'] = ' username\n'
+
+    assert parse_env(args) == {
+        'a_var': 'username',
+    }


### PR DESCRIPTION
I ran into this problem of having env vars set with whitespaces (because of the use of some stupid tool that caused this), so I ended up having values that failed to parse (some hostname that ended up with `\n` to give an example :) ) 

Hence, this PR which suggests a solution to that problem. 

Cheers,
Sherif.